### PR TITLE
Use arguments to xprop

### DIFF
--- a/usr/bin/xpop
+++ b/usr/bin/xpop
@@ -3,7 +3,5 @@
 # A wrapper around xprop to easily get class and name of windows.
 
 zenity --info --no-markup --text "$(\
-	xprop \
-		| grep --color=none \
-		"^WM_CLASS\|^WM_NAME\|^WM_WINDOW_ROLE\|^WM_TRANSIENT_FOR\|^_NET_WM_WINDOW_TYPE\|^_NET_WM_STATE\|^_NET_WM_PID" \
+	xprop WM_CLASS WM_NAME WM_WINDOW_ROLE WM_TRANSIENT_FOR _NET_WM_WINDOW_TYPE _NET_WM_STATE _NET_WM_PID \
 	)"


### PR DESCRIPTION
Instead of filtering xprop's output with grep, this gives it the interesting atoms on the command line.

Note that this changes the output, since xprop will report "not found." for properties that were requested, but aren't present.
Also note that I didn't actually test this change, but only entered it on GitHub.
